### PR TITLE
Switch from classes to Plain Old Javascript Objects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,11 @@ import { EducationDetails } from './Components/EducationForm';
 import Education from './Components/Education';
 import { ExperienceDetails } from './Components/ExperienceForm';
 import Experience from './Components/Experience';
+import { ProjectDetails } from './Components/ProjectForm';
+import Project from './Components/Project';
+import Sidebar from './Components/Sidebar';
+import Preview from './Components/Preview';
+import SkillsForm, { SkillsDetails } from './Components/SkillsForm';
 import {
   initialContactDetails,
   initialEducationDetails,
@@ -12,17 +17,6 @@ import {
   initialProjectDetails,
   initialSkillsDetails,
 } from './lib/initialState';
-import { ProjectDetails } from './Components/ProjectForm';
-import Project from './Components/Project';
-import Sidebar from './Components/Sidebar';
-import Preview from './Components/Preview';
-import ContactPreview from './Components/ContactPreview';
-import EducationPreview from './Components/EducationPreview';
-import ExperiencePreview from './Components/ExperiencePreview';
-import ProjectPreview from './Components/ProjectPreview';
-import SkillsForm, { SkillsDetails } from './Components/SkillsForm';
-import SkillsPreview from './Components/SkillsPreview';
-import CopyTexButton from './Components/CopyTexButton';
 
 function App() {
   const [contactDetails, setContactDetails] = useState<ContactDetails>(

--- a/src/Components/ContactForm.tsx
+++ b/src/Components/ContactForm.tsx
@@ -1,26 +1,12 @@
 import { ChangeEvent, Dispatch, SetStateAction } from 'react';
 import Input from './Input';
 
-class ContactDetails {
+interface ContactDetails {
   fullName: string;
   phoneNumber: string;
   github: string;
   linkedIn: string;
   gmail: string;
-
-  constructor({
-    fullName = '',
-    phoneNumber = '',
-    github = '',
-    linkedIn = '',
-    gmail = '',
-  }) {
-    this.fullName = fullName;
-    this.phoneNumber = phoneNumber;
-    this.github = github;
-    this.linkedIn = linkedIn;
-    this.gmail = gmail;
-  }
 }
 
 interface ContactFormProps {
@@ -75,6 +61,5 @@ function ContactForm({ contactDetails, setContactDetails }: ContactFormProps) {
   );
 }
 
-export type { ContactFormProps };
-export { ContactDetails };
+export type { ContactDetails, ContactFormProps };
 export default ContactForm;

--- a/src/Components/Education.tsx
+++ b/src/Components/Education.tsx
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction, useState } from 'react';
 import EducationForm, { EducationDetails } from './EducationForm';
 import DetailItem from './DetailItem';
-import { UUIDString } from '../lib/types';
+import generateUniqueId, { UUIDString } from '../lib/uniqueId';
 
 interface EducationProps {
   educationDetails: EducationDetails[];
@@ -15,15 +15,24 @@ function Education({ educationDetails, setEducationDetails }: EducationProps) {
     activeId && educationDetails.find((detail) => detail.id === activeId);
 
   function handleClick() {
-    const newDetails = new EducationDetails();
+    const newDetails = {
+      id: generateUniqueId(),
+      collegeName: '',
+      degree: '',
+      gpa: '',
+      coursework: '',
+      isVisible: true,
+      startDate: new Date(),
+      endDate: new Date(),
+    } satisfies EducationDetails;
+
     setEducationDetails(educationDetails.concat(newDetails));
     setActiveId(newDetails.id);
   }
 
   function toggleHide(id: UUIDString) {
     const oldDetails = educationDetails.find((detail) => detail.id === id)!;
-    const newDetails = oldDetails.clone();
-    newDetails.isVisible = !newDetails.isVisible;
+    const newDetails = { ...oldDetails, isVisible: !oldDetails.isVisible };
 
     setEducationDetails(
       educationDetails.map((detail) => {

--- a/src/Components/EducationPreview.tsx
+++ b/src/Components/EducationPreview.tsx
@@ -1,3 +1,4 @@
+import { getDuration } from '../lib/dateUtils';
 import { EducationDetails } from './EducationForm';
 
 function Coursework({
@@ -26,7 +27,7 @@ function EducationPreviewItem({
   educationDetails: EducationDetails;
 }) {
   const { collegeName, degree, gpa } = educationDetails;
-  const [startDate, endDate] = educationDetails.duration;
+  const [startDate, endDate] = getDuration(educationDetails.startDate, educationDetails.endDate);
 
   return (
     <section className='preview-item'>

--- a/src/Components/Experience.tsx
+++ b/src/Components/Experience.tsx
@@ -1,7 +1,8 @@
 import { Dispatch, SetStateAction, useState } from 'react';
 import ExperienceForm, { ExperienceDetails } from './ExperienceForm';
-import { UUIDString } from '../lib/types';
 import DetailItem from './DetailItem';
+import generateUniqueId, { UUIDString } from '../lib/uniqueId';
+import { initialExperienceDetails } from '../lib/initialState';
 
 interface ExperienceProps {
   experienceDetails: ExperienceDetails[];
@@ -17,15 +18,18 @@ function Experience({
     activeId && experienceDetails.find((detail) => detail.id === activeId);
 
   function handleClick() {
-    const newDetails = new ExperienceDetails();
+    const newDetails = {
+      ...initialExperienceDetails[0],
+      id: generateUniqueId(),
+    } satisfies ExperienceDetails;
+
     setExperienceDetails(experienceDetails.concat(newDetails));
     setActiveId(newDetails.id);
   }
 
   function toggleHide(id: UUIDString) {
     const oldDetails = experienceDetails.find((detail) => detail.id === id)!;
-    const newDetails = oldDetails.clone();
-    newDetails.isVisible = !newDetails.isVisible;
+    const newDetails = { ...oldDetails, isVisible: !oldDetails.isVisible };
 
     setExperienceDetails(
       experienceDetails.map((detail) => {

--- a/src/Components/ExperienceForm.tsx
+++ b/src/Components/ExperienceForm.tsx
@@ -1,107 +1,18 @@
 import { ChangeEvent, Dispatch, FormEvent, SetStateAction } from 'react';
 import Input from './Input';
 import TextArea from './TextArea';
-import { DateString, UUIDString } from '../lib/types';
-import generateUniqueId from '../lib/uniqueId';
+import { UUIDString } from '../lib/uniqueId';
+import { formatDate } from '../lib/dateUtils';
 
-class ExperienceDetails {
+interface ExperienceDetails {
   id: UUIDString;
   orgName: string;
   jobTitle: string;
   location: string;
   description: string;
+  startDate: Date;
+  endDate: Date;
   isVisible: boolean;
-  #startDate: Date = new Date();
-  #endDate: Date = new Date();
-  [key: string]: string | boolean | string[] | (() => ExperienceDetails);
-
-  constructor({
-    id = generateUniqueId(),
-    orgName = '',
-    jobTitle = '',
-    location = '',
-    description = '',
-    startDate = new Date(),
-    endDate = new Date(),
-    isVisible = true,
-  } = {}) {
-    this.id = id;
-    this.orgName = orgName;
-    this.jobTitle = jobTitle;
-    this.location = location;
-    this.description = description;
-    this.startDate = startDate;
-    this.endDate = endDate;
-    this.isVisible = isVisible;
-  }
-
-  set startDate(date: Date | DateString) {
-    this.#startDate = date instanceof Date ? date : this.#parseDate(date);
-  }
-
-  get startDate(): DateString {
-    return this.#formatDate(this.#startDate);
-  }
-
-  set endDate(date: Date | DateString) {
-    this.#endDate = date instanceof Date ? date : this.#parseDate(date);
-  }
-
-  get endDate(): DateString {
-    return this.#formatDate(this.#endDate);
-  }
-
-  get duration() {
-    const start = `${ExperienceDetails.shortenDate(this.#startDate)}`;
-    const endMonth = this.#endDate.getMonth();
-    const endYear = this.#endDate.getFullYear();
-
-    const presentDate = new Date();
-    const thisMonth = presentDate.getMonth();
-    const thisYear = presentDate.getFullYear();
-
-    const end =
-      endMonth === thisMonth && endYear === thisYear
-        ? 'Present'
-        : `${ExperienceDetails.shortenDate(this.#endDate)}`;
-
-    return [start, end];
-  }
-
-  static shortenDate(date: Date) {
-    const userLocale = navigator.languages[0];
-    const formatter = new Intl.DateTimeFormat(userLocale, {
-      month: 'short',
-      year: 'numeric',
-    });
-
-    const [month, year] = formatter.format(date).split(' ');
-    return `${month}. ${year}`;
-  }
-
-  clone(): ExperienceDetails {
-    return new ExperienceDetails({
-      id: this.id,
-      orgName: this.orgName,
-      jobTitle: this.jobTitle,
-      location: this.location,
-      description: this.description,
-      isVisible: this.isVisible,
-      startDate: this.#startDate,
-      endDate: this.#endDate,
-    });
-  }
-
-  #formatDate(date: Date): DateString {
-    const year = date.getFullYear();
-    const month = (date.getMonth() + 1).toString().padStart(2, '0'); // 0 indexed month
-    const day = date.getDate().toString().padStart(2, '0');
-    return `${year}-${month}-${day}`;
-  }
-
-  #parseDate(dateString: DateString): Date {
-    return dateString.length === 0 ? new Date() : new Date(dateString);
-  }
 }
 
 interface ExperienceFormProps {
@@ -117,9 +28,7 @@ function ExperienceForm({
   setExperienceDetails,
   setActiveId,
 }: ExperienceFormProps) {
-  const detailIndex = experienceDetails.findIndex(
-    (detail: ExperienceDetails) => detail.id === id
-  );
+  const detailIndex = experienceDetails.findIndex((detail) => detail.id === id);
 
   const { orgName, jobTitle, location, description, startDate, endDate } =
     experienceDetails.at(detailIndex)!;
@@ -128,13 +37,13 @@ function ExperienceForm({
     const field = e.target.name;
     const value = e.target.value;
     const originalDetails = experienceDetails.at(detailIndex)!;
-    const newDetails = originalDetails.clone();
-    newDetails[field] = value;
+    const newDetails = { ...originalDetails, [field]: value };
 
     const newEducationDetails = experienceDetails.map((details) => {
       if (details.id === id) return newDetails;
       return details;
     });
+
     setExperienceDetails(newEducationDetails);
   }
 
@@ -180,14 +89,14 @@ function ExperienceForm({
         label='Start Date: '
         type='Date'
         name='startDate'
-        value={startDate}
+        value={formatDate(startDate)}
         onChange={handleFieldChange}
       />
       <Input
         label='End Date: '
         type='Date'
         name='endDate'
-        value={endDate}
+        value={formatDate(endDate)}
         onChange={handleFieldChange}
       />
       <button className='btn-save' type='submit'>
@@ -197,5 +106,5 @@ function ExperienceForm({
   );
 }
 
-export { ExperienceDetails };
+export type { ExperienceDetails };
 export default ExperienceForm;

--- a/src/Components/ExperiencePreview.tsx
+++ b/src/Components/ExperiencePreview.tsx
@@ -1,3 +1,4 @@
+import { getDuration } from '../lib/dateUtils';
 import { ExperienceDetails } from './ExperienceForm';
 
 function EducationPreviewItem({
@@ -6,7 +7,10 @@ function EducationPreviewItem({
   experienceDetails: ExperienceDetails;
 }) {
   const { orgName, jobTitle, description, location } = experienceDetails;
-  const [startDate, endDate] = experienceDetails.duration;
+  const [startDate, endDate] = getDuration(
+    experienceDetails.startDate,
+    experienceDetails.endDate
+  );
 
   return (
     <section className='preview-item'>

--- a/src/Components/Project.tsx
+++ b/src/Components/Project.tsx
@@ -1,7 +1,8 @@
 import { Dispatch, SetStateAction, useState } from 'react';
 import ProjectForm, { ProjectDetails } from './ProjectForm';
-import { UUIDString } from '../lib/types';
 import DetailItem from './DetailItem';
+import { initialProjectDetails } from '../lib/initialState';
+import generateUniqueId, { UUIDString } from '../lib/uniqueId';
 
 interface ProjectProps {
   projectDetails: ProjectDetails[];
@@ -14,15 +15,14 @@ function Project({ projectDetails, setProjectDetails }: ProjectProps) {
     activeId && projectDetails.find((detail) => detail.id === activeId);
 
   function handleClick() {
-    const newDetails = new ProjectDetails();
+    const newDetails = { ...initialProjectDetails[0], id: generateUniqueId() };
     setProjectDetails(projectDetails.concat(newDetails));
     setActiveId(newDetails.id);
   }
 
   function toggleHide(id: UUIDString) {
     const oldDetails = projectDetails.find((detail) => detail.id === id)!;
-    const newDetails = oldDetails.clone();
-    newDetails.isVisible = !newDetails.isVisible;
+    const newDetails = { ...oldDetails, isVisible: !oldDetails.isVisible };
 
     setProjectDetails(
       projectDetails.map((detail) => {

--- a/src/Components/ProjectForm.tsx
+++ b/src/Components/ProjectForm.tsx
@@ -1,103 +1,17 @@
 import { ChangeEvent, Dispatch, FormEvent, SetStateAction } from 'react';
-import { DateString, UUIDString } from '../lib/types';
-import generateUniqueId from '../lib/uniqueId';
+import { UUIDString } from '../lib/uniqueId';
 import Input from './Input';
 import TextArea from './TextArea';
+import { formatDate } from '../lib/dateUtils';
 
-class ProjectDetails {
+interface ProjectDetails {
   id: UUIDString;
   name: string;
   techUsed: string;
   description: string;
   isVisible: boolean;
-  #startDate: Date = new Date();
-  #endDate: Date = new Date();
-  [key: string]: string | boolean | string[] | (() => ProjectDetails);
-
-  constructor({
-    id = generateUniqueId(),
-    name = '',
-    techUsed = '',
-    description = '',
-    startDate = new Date(),
-    endDate = new Date(),
-    isVisible = true,
-  } = {}) {
-    this.id = id;
-    this.name = name;
-    this.techUsed = techUsed;
-    this.description = description;
-    this.startDate = startDate;
-    this.endDate = endDate;
-    this.isVisible = isVisible;
-  }
-
-  set startDate(date: Date | DateString) {
-    this.#startDate = date instanceof Date ? date : this.#parseDate(date);
-  }
-
-  get startDate(): DateString {
-    return this.#formatDate(this.#startDate);
-  }
-
-  set endDate(date: Date | DateString) {
-    this.#endDate = date instanceof Date ? date : this.#parseDate(date);
-  }
-
-  get endDate(): DateString {
-    return this.#formatDate(this.#endDate);
-  }
-
-  get duration() {
-    const start = `${ProjectDetails.shortenDate(this.#startDate)}`;
-    const endMonth = this.#endDate.getMonth();
-    const endYear = this.#endDate.getFullYear();
-
-    const presentDate = new Date();
-    const thisMonth = presentDate.getMonth();
-    const thisYear = presentDate.getFullYear();
-
-    const end =
-      endMonth === thisMonth && endYear === thisYear
-        ? 'Present'
-        : `${ProjectDetails.shortenDate(this.#endDate)}`;
-
-    return [start, end];
-  }
-
-  static shortenDate(date: Date) {
-    const userLocale = navigator.languages[0];
-    const formatter = new Intl.DateTimeFormat(userLocale, {
-      month: 'short',
-      year: 'numeric',
-    });
-
-    const [month, year] = formatter.format(date).split(' ');
-    return `${month}. ${year}`;
-  }
-
-  clone(): ProjectDetails {
-    return new ProjectDetails({
-      id: this.id,
-      name: this.name,
-      techUsed: this.techUsed,
-      description: this.description,
-      isVisible: this.isVisible,
-      startDate: this.#startDate,
-      endDate: this.#endDate,
-    });
-  }
-
-  #formatDate(date: Date): DateString {
-    const year = date.getFullYear();
-    const month = (date.getMonth() + 1).toString().padStart(2, '0'); // 0 indexed month
-    const day = date.getDate().toString().padStart(2, '0');
-    return `${year}-${month}-${day}`;
-  }
-
-  #parseDate(dateString: DateString): Date {
-    return dateString.length === 0 ? new Date() : new Date(dateString);
-  }
+  startDate: Date;
+  endDate: Date;
 }
 
 interface ProjectFormProps {
@@ -124,13 +38,13 @@ function ProjectForm({
     const field = e.target.name;
     const value = e.target.value;
     const originalDetails = projectDetails.at(detailIndex)!;
-    const newDetails = originalDetails.clone();
-    newDetails[field] = value;
+    const newDetails = { ...originalDetails, [field]: value };
 
     const newProjectDetails = projectDetails.map((details) => {
       if (details.id === id) return newDetails;
       return details;
     });
+
     setProjectDetails(newProjectDetails);
   }
 
@@ -169,14 +83,15 @@ function ProjectForm({
         label='Start Date: '
         type='Date'
         name='startDate'
-        value={startDate}
+        value={formatDate(startDate)}
         onChange={handleFieldChange}
       />
+
       <Input
         label='End Date: '
         type='Date'
         name='endDate'
-        value={endDate}
+        value={formatDate(endDate)}
         onChange={handleFieldChange}
       />
       <button className='btn-save' type='submit'>
@@ -186,5 +101,5 @@ function ProjectForm({
   );
 }
 
-export { ProjectDetails };
+export type { ProjectDetails };
 export default ProjectForm;

--- a/src/Components/ProjectPreview.tsx
+++ b/src/Components/ProjectPreview.tsx
@@ -1,3 +1,4 @@
+import { getDuration } from '../lib/dateUtils';
 import { ProjectDetails } from './ProjectForm';
 
 function ProjectPreviewItemDescription({
@@ -23,7 +24,7 @@ function ProjectPreviewItem({
   projectDetails: ProjectDetails;
 }) {
   const { name, techUsed, description } = projectDetails;
-  const [startDate, endDate] = projectDetails.duration;
+  const [startDate, endDate] = getDuration(projectDetails.startDate, projectDetails.endDate);
 
   return (
     <section className='preview-item'>

--- a/src/Components/SkillsForm.tsx
+++ b/src/Components/SkillsForm.tsx
@@ -1,23 +1,11 @@
 import { ChangeEvent, Dispatch, SetStateAction } from 'react';
 import Input from './Input';
 
-class SkillsDetails {
+interface SkillsDetails {
   languages: string;
   frameworks: string;
   devTools: string;
   libraries: string;
-
-  constructor({
-    languages = '',
-    frameworks = '',
-    devTools = '',
-    libraries = '',
-  } = {}) {
-    this.languages = languages;
-    this.frameworks = frameworks;
-    this.devTools = devTools;
-    this.libraries = libraries;
-  }
 }
 
 interface SkillsFormProps {
@@ -45,7 +33,7 @@ function SkillsForm({ skillsDetails, setSkillsDetails }: SkillsFormProps) {
       />
       <Input
         label='Frameworks'
-        name='Frameworks'
+        name='frameworks'
         value={frameworks}
         onChange={handleFieldChange}
       />
@@ -65,6 +53,5 @@ function SkillsForm({ skillsDetails, setSkillsDetails }: SkillsFormProps) {
   );
 }
 
-export type { SkillsFormProps };
-export { SkillsDetails };
+export type { SkillsDetails, SkillsFormProps };
 export default SkillsForm;

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,0 +1,45 @@
+type DateString = `${string}-${string}-${string}`;
+
+function formatDate(date: Date): DateString {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0'); // 0 indexed month
+  const day = date.getDate().toString().padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function parseDate(dateString: DateString): Date {
+  // Handle cleared dates
+  return dateString.length === 0 ? new Date() : new Date(dateString);
+}
+
+function shortenDate(date: Date) {
+  const userLocale = navigator.languages[0];
+  const formatter = new Intl.DateTimeFormat(userLocale, {
+    month: 'short',
+    year: 'numeric',
+  });
+
+  const [month, year] = formatter.format(date).split(' ');
+  return `${month}. ${year}`;
+}
+
+function getDuration(startDate: Date, endDate: Date) {
+  const start = `${shortenDate(startDate)}`;
+  const endMonth = endDate.getMonth();
+  const endYear = endDate.getFullYear();
+
+  const presentDate = new Date();
+  const thisMonth = presentDate.getMonth();
+  const thisYear = presentDate.getFullYear();
+
+  const end =
+    endMonth === thisMonth && endYear === thisYear
+      ? 'Present'
+      : `${shortenDate(endDate)}`;
+
+  return [start, end];
+}
+
+export type { DateString };
+
+export { parseDate, formatDate, shortenDate, getDuration };

--- a/src/lib/initialState.ts
+++ b/src/lib/initialState.ts
@@ -40,12 +40,16 @@ const initialExperienceDetails = [
 ] satisfies ExperienceDetails[];
 
 const initialProjectDetails = [
-  new ProjectDetails({
+  {
+    id: generateUniqueId(),
     name: 'First Project',
     techUsed: 'Javascript',
     description: 'Very cool!',
-  }),
-];
+    startDate: new Date(),
+    endDate: new Date(),
+    isVisible: true,
+  },
+] satisfies ProjectDetails[];
 
 const initialSkillsDetails = new SkillsDetails({
   languages: 'Javascript',

--- a/src/lib/initialState.ts
+++ b/src/lib/initialState.ts
@@ -3,6 +3,7 @@ import { EducationDetails } from '../Components/EducationForm';
 import { ExperienceDetails } from '../Components/ExperienceForm';
 import { ProjectDetails } from '../Components/ProjectForm';
 import { SkillsDetails } from '../Components/SkillsForm';
+import generateUniqueId from './uniqueId';
 
 const initialContactDetails = new ContactDetails({
   fullName: 'John Doe',
@@ -13,12 +14,17 @@ const initialContactDetails = new ContactDetails({
 });
 
 const initialEducationDetails = [
-  new EducationDetails({
+  {
+    id: generateUniqueId(),
     collegeName: 'College McCollegePants',
     degree: 'McMasters',
     gpa: '4.20',
-  }),
-];
+    coursework: 'Stuff',
+    isVisible: true,
+    startDate: new Date(),
+    endDate: new Date(),
+  },
+] satisfies EducationDetails[];
 
 const initialExperienceDetails = [
   new ExperienceDetails({

--- a/src/lib/initialState.ts
+++ b/src/lib/initialState.ts
@@ -5,13 +5,13 @@ import { ProjectDetails } from '../Components/ProjectForm';
 import { SkillsDetails } from '../Components/SkillsForm';
 import generateUniqueId from './uniqueId';
 
-const initialContactDetails = new ContactDetails({
+const initialContactDetails = {
   fullName: 'John Doe',
   phoneNumber: '123-456-7890',
   github: 'johnDoe',
   linkedIn: 'johnDoe',
   gmail: 'johnDoe@gmail.com',
-});
+} satisfies ContactDetails;
 
 const initialEducationDetails = [
   {

--- a/src/lib/initialState.ts
+++ b/src/lib/initialState.ts
@@ -51,12 +51,12 @@ const initialProjectDetails = [
   },
 ] satisfies ProjectDetails[];
 
-const initialSkillsDetails = new SkillsDetails({
+const initialSkillsDetails = {
   languages: 'Javascript',
   frameworks: 'ReactJS',
   devTools: 'Git, VS Code',
   libraries: 'Jest',
-});
+} satisfies SkillsDetails;
 
 export {
   initialContactDetails,

--- a/src/lib/initialState.ts
+++ b/src/lib/initialState.ts
@@ -27,13 +27,17 @@ const initialEducationDetails = [
 ] satisfies EducationDetails[];
 
 const initialExperienceDetails = [
-  new ExperienceDetails({
+  {
+    id: generateUniqueId(),
     orgName: 'Rubocop',
     jobTitle: 'Cop',
     description: 'Cop for rubies',
     location: 'New York',
-  }),
-];
+    startDate: new Date(),
+    endDate: new Date(),
+    isVisible: true,
+  },
+] satisfies ExperienceDetails[];
 
 const initialProjectDetails = [
   new ProjectDetails({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,3 @@
-type DateString = `${string}-${string}-${string}`;
-type UUIDString = `${string}-${string}-${string}-${string}-${string}`;
+type Maybe<T> = T | null;
 
-export type { DateString, UUIDString };
+export type { Maybe };

--- a/src/lib/uniqueId.ts
+++ b/src/lib/uniqueId.ts
@@ -1,5 +1,6 @@
-import { UUIDString } from "./types";
+type UUIDString = `${string}-${string}-${string}-${string}-${string}`;
 
+export type { UUIDString };
 export default function generateUniqueId(): UUIDString {
   return crypto.randomUUID();
 }


### PR DESCRIPTION
This PR
- Switches class declarations to interfaces
- Unifies date formatting and parsing logic
- Switches constructor calls with plain object creation